### PR TITLE
Correção bugs do template

### DIFF
--- a/src/main/webapp/WEB-INF/tags/login.tag
+++ b/src/main/webapp/WEB-INF/tags/login.tag
@@ -39,9 +39,12 @@
 </head>
 <body>
 <header>
-    <nav>
-        <div class="nav-wrapper light-blue darken-4">
-            <a href="#!" class="brand-logo"><i class="material-icons">directions_car</i>Logo</a>
+    <nav class="nav-wrapper light-blue darken-4">
+        <div class="container">
+            <a href="#!" class="brand-logo">
+                <img src="assets/res/img/logo2.png">
+                <h2>Sistema de Oficinas Mecânicas</h2>
+            </a>
         </div>
     </nav>
 </header>

--- a/src/main/webapp/WEB-INF/tags/template.tag
+++ b/src/main/webapp/WEB-INF/tags/template.tag
@@ -151,7 +151,9 @@
     </ul>
 </header>
 <main>
-    <jsp:doBody/>
+    <div class="min-height">
+        <jsp:doBody/>
+    </div>
 
     <!-- rodape-->
     <footer class="page-footer light-blue darken-4">

--- a/src/main/webapp/assets/res/css/index.css
+++ b/src/main/webapp/assets/res/css/index.css
@@ -178,6 +178,10 @@ a {
 	color: grey;
 }
 
+.min-height {
+	min-height: 100vh;
+}
+
 #type-vehicle {
 	padding-top: 15px;
 }

--- a/src/main/webapp/assets/res/css/login.css
+++ b/src/main/webapp/assets/res/css/login.css
@@ -32,6 +32,21 @@
     padding: 16px 24px;
 }
 
+.brand-logo img{
+    display: inline-block;
+    width: 100px;
+    border-radius: 10px;
+    padding-top: 5px;
+}
+
+.brand-logo h2{
+    display: inline-block;
+    font-size: 30px;
+    margin: 0;
+    padding: 14px 0 0 5px;
+    vertical-align: top;
+}
+
 
 a {
     color: #01579b;


### PR DESCRIPTION
- [x] Em algumas situações, o rodapé flutua na tela, ele deve estar alinhado em baixo, independe se há conteúdo acima.
- [x] No login, colocar a classe container do materialize para centralizar o conteúdo das extremidades (ícone da aplicação), apresentando uma margem.
- [x] Colocar o ícone que aparece nas páginas autenticadas também na tela de login no lugar do carrinho simples. 
- [x] Na tela de login, colocar o nome Sistema de Oficinas Mecânicas no lugar da palavra Logo

Preview:
![Screenshot from 2019-11-27 14-01-59](https://user-images.githubusercontent.com/49662698/69744201-7fdb7000-111e-11ea-8564-ae21a846547b.png)

![Peek 2019-11-27 14-06](https://user-images.githubusercontent.com/49662698/69744557-2cb5ed00-111f-11ea-8705-4fe19a14f63f.gif)
