### PR TITLE
Correção - Bug cadastro veículo

### DIFF
--- a/src/main/java/br/edu/utfpr/autorepairshop/controller/VehicleController.java
+++ b/src/main/java/br/edu/utfpr/autorepairshop/controller/VehicleController.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequestMapping("/veiculos")
-@PreAuthorize("hasAnyRole('ADMIN') or hasAnyRole('MANAGER') or hasAnyRole('EMPLOYEE')")
+@PreAuthorize("hasAnyRole('ADMIN') or hasAnyRole('MANAGER') or hasAnyRole('EMPLOYEE') or hasAnyRole('CLIENT')")
 @Controller
 public class VehicleController {
 


### PR DESCRIPTION
Descrição: Ao clicar no ícone de +, ao invés de apresentar o formulário de cadastro de veículo, remete ao login, mesmo estando logado.